### PR TITLE
Fixed loadUserIdFromUsername function by changing get request to post…

### DIFF
--- a/srcs/Api.js
+++ b/srcs/Api.js
@@ -62,9 +62,13 @@ class Api {
     return objs;
   }
 
-  async loadUserIdFromUsername(username) {
+  async loadUserIdFromUsername(username, password) {
     try {
-      const { data } = await this.axios.get(`https://medal.tv/u/${username}`);
+      const url = "https://medal.tv/u/" + username
+      const { data } = await this.axios.post(url, {
+            userName: username,
+            password: password
+      });
       const userIdInResponse = /"userId":"([0-9]+)/gm.exec(data);
       if (userIdInResponse) {
         return userIdInResponse[1];

--- a/srcs/Api.js
+++ b/srcs/Api.js
@@ -64,14 +64,14 @@ class Api {
 
   async loadUserIdFromUsername(username, password) {
     try {
-      const url = "https://medal.tv/u/" + username
+      const url = "https://api-v2.medal.tv/authentication"
       const { data } = await this.axios.post(url, {
             userName: username,
             password: password
       });
-      const userIdInResponse = /"userId":"([0-9]+)/gm.exec(data);
+      const userIdInResponse = data.userId
       if (userIdInResponse) {
-        return userIdInResponse[1];
+        return userIdInResponse;
       }
     } catch (e) {
       console.error(e);

--- a/srcs/index.js
+++ b/srcs/index.js
@@ -95,7 +95,7 @@ async function downloadAll(videos, maxSimultaneous) {
   }));
 }
 
-async function loadUserId(api, userUrl, username) {
+async function loadUserId(api, userUrl, username, password) {
   let userId = null;
   if (userUrl) {
     userId = await api.loadUserIdFromUrl(userUrl);
@@ -103,7 +103,7 @@ async function loadUserId(api, userUrl, username) {
       console.error(`Invalid user url: ${userUrl}`);
     }
   } else if (username) {
-    userId = await api.loadUserIdFromUsername(username);
+    userId = await api.loadUserIdFromUsername(username, password);
     if (!userId) {
       console.error(`Invalid username: ${username}`);
     }
@@ -124,7 +124,7 @@ async function run(userUrl, username, password, categoryId) {
     return;
   }
 
-  const userId = await loadUserId(api, userUrl, username);
+  const userId = await loadUserId(api, userUrl, username, password);
   if (!userId) {
     return;
   }


### PR DESCRIPTION
Fixed loadUserIdFromUsername function by changing get request to post request with credentials.<br>
The function used to have an issue finding the username without the credentials with the GET request.<br>
The new POST request takes the credentials and receives as a response which includes the userId.<br>
You can test it with `medal-downloader --username your_username --password your_password`